### PR TITLE
Fix compilation from scratch

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ This repository is experimental - the 0.0.1 tag is not stable.
 
 ```
 opam switch create llir \
-  --repositories=llir=git+https://github.com/nandor/llir-opam-repository \
+  --repositories=llir=git+https://github.com/nandor/llir-opam-repository,default \
   --empty
 opam update
-opam install ocaml-variants.4.11.0.0.0.1+llir
+opam install ocaml-variants=4.11.1.master+llir arch-amd64
 ```
 
 ## References

--- a/packages/binutils/binutils-amd64.2.35/opam
+++ b/packages/binutils/binutils-amd64.2.35/opam
@@ -24,6 +24,9 @@ build: [
       "--disable-intl"
       "CC=gcc"
       "CXX=g++"
+      "AR=ar"
+      "RANLIB=ranlib"
+      "LD=ld"
   ]
   [
     make "-j%{jobs}%"

--- a/packages/binutils/binutils-arm64.2.35/opam
+++ b/packages/binutils/binutils-arm64.2.35/opam
@@ -24,6 +24,9 @@ build: [
       "--disable-intl"
       "CC=gcc"
       "CXX=g++"
+      "AR=ar"
+      "RANLIB=ranlib"
+      "LD=ld"
   ]
   [
     make "-j%{jobs}%"

--- a/packages/binutils/binutils-i686.2.35/opam
+++ b/packages/binutils/binutils-i686.2.35/opam
@@ -24,6 +24,9 @@ build: [
       "--disable-intl"
       "CC=gcc"
       "CXX=g++"
+      "AR=ar"
+      "RANLIB=ranlib"
+      "LD=ld"
   ]
   [
     make "-j%{jobs}%"

--- a/packages/binutils/binutils-power.2.35/opam
+++ b/packages/binutils/binutils-power.2.35/opam
@@ -24,6 +24,9 @@ build: [
       "--disable-intl"
       "CC=gcc"
       "CXX=g++"
+      "AR=ar"
+      "RANLIB=ranlib"
+      "LD=ld"
   ]
   [
     make "-j%{jobs}%"

--- a/packages/binutils/binutils-riscv32.2.35/opam
+++ b/packages/binutils/binutils-riscv32.2.35/opam
@@ -24,6 +24,9 @@ build: [
       "--disable-intl"
       "CC=gcc"
       "CXX=g++"
+      "AR=ar"
+      "RANLIB=ranlib"
+      "LD=ld"
   ]
   [
     make "-j%{jobs}%"

--- a/packages/binutils/binutils-riscv64.2.35/opam
+++ b/packages/binutils/binutils-riscv64.2.35/opam
@@ -24,6 +24,9 @@ build: [
       "--disable-intl"
       "CC=gcc"
       "CXX=g++"
+      "AR=ar"
+      "RANLIB=ranlib"
+      "LD=ld"
   ]
   [
     make "-j%{jobs}%"

--- a/packages/llir-musl/llir-musl-amd64.master+llir/opam
+++ b/packages/llir-musl/llir-musl-amd64.master+llir/opam
@@ -9,6 +9,9 @@ build: [
     "./configure"
       "--prefix=%{prefix}%"
       "--target=llir_x86_64-unknown-linux-musl"
+      "CC=llir_x86_64-unknown-linux-musl-gcc"
+      "AR=llir_x86_64-unknown-linux-musl-ar"
+      "RANLIB=llir_x86_64-unknown-linux-musl-ranlib"
   ]
   [ make "-j" jobs ]
 ]


### PR DESCRIPTION
These changes are required to install on Arch Linux from scratch:

- Also pass system ar, ranlib and ld to the build scripts of binutils. Otherwise they fail trying to use llir_x86_64-unknown-linux-{ar,ranlib,ld}
- configure cc/ld/ranlib for the musl package. These are in line with the setenv command, which doesn't seem to get picked up
- Update the installation instructions: Now uses the default repository for the ocaml package, and suggested to add arch-amd64, otherwise it defaults to arch-power